### PR TITLE
Allow to use the internal PHP server

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,5 +4,10 @@ if (version_compare($ver = PHP_VERSION, $req = '5.4.0', '<')) {
 	exit(sprintf('You are running PHP %s, but Pagekit needs at least <strong>PHP %s</strong> to run.', $ver, $req));
 }
 
+// Deliver static files for internal server
+if (php_sapi_name() === 'cli-server' && is_file(__DIR__.parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))) {
+    return false;
+}
+
 $app = require_once __DIR__.'/app/app.php';
 $app->run();


### PR DESCRIPTION
Little hack found on Silex documentation: http://silex.sensiolabs.org/doc/web_servers.html#php-5-4

To run the server:

```
php -S 127.0.0.1:8080 index.php
```
