### PR TITLE
Configure Apache to serve SVG files with correct mime type

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,6 @@
+AddType image/svg+xml svg svgz
+AddEncoding gzip svgz
+
 <IfModule mod_rewrite.c>
     SetEnv HTTP_MOD_REWRITE On
 


### PR DESCRIPTION
Some Apache servers aren't properly configured and serve .svg files with XML mime type.
Especially Webkit-based browsers such as Safari and Chrome won't show these graphics in that case.
