### PR TITLE
Fix inconsistent messages after deleting users.

### DIFF
--- a/extensions/system/src/User/Controller/UserController.php
+++ b/extensions/system/src/User/Controller/UserController.php
@@ -226,7 +226,7 @@ class UserController extends Controller
             }
         }
 
-		if(count($deletedIds) > 0 || count($ids) === 0) {
+	if(count($deletedIds) > 0 || count($ids) === 0) {
         	$this['message']->success(_c('{0} No user deleted.|{1} User deleted.|]1,Inf[ Users deleted.', count($deletedIds)));
         }
         


### PR DESCRIPTION
Fixes inconsistent messages after trying to delete own user. It returned both "Unable to delete self." and "User deleted.". Now it will only return "Unable to delete self." if the only user which should be deleted was the own.
