### PR TITLE
Remove the need for the app root to be writable if the config already exists

### DIFF
--- a/app/requirements.php
+++ b/app/requirements.php
@@ -444,7 +444,15 @@ class PagekitRequirements extends RequirementCollection
         }
 
         $path = $app['path'];
-        foreach (array($path, "$path/app/cache", "$path/app/logs", "$path/app/sessions", "$path/app/temp") as $dir) {
+        $writable_directories = ["$path/app/cache", "$path/app/logs", "$path/app/sessions", "$path/app/temp"];
+
+        if (!file_exists("$path/config.php")) {
+          // If config.php doesn't exist, we need the root directory of the app
+          // to be writable.
+          array_unshift($writable_directories, $path);
+        }
+
+        foreach ($writable_directories as $dir) {
             $this->addRequirement(
                 is_writable($dir),
                 "{$dir} directory must be writable",


### PR DESCRIPTION
It is very unfortunate that the installer requires the root directory of the app (which is also the document root) to be writable, as it goes against well established security practices.

Fortunately, as long as a `config.php` exists, Pagekit doesn't seem to actually require that. This PR updates the requirements checks from `app/requirements.php` so as to only mandates that the root directory is writable if there is no `config.php` already in place.
