### PR TITLE
Fix path to settings view in skeleton

### DIFF
--- a/extensions/system/src/System/Console/skeleton/extension/extension.php
+++ b/extensions/system/src/System/Console/skeleton/extension/extension.php
@@ -22,7 +22,7 @@ return [
 
     'settings' => [
 
-        'system' => '%NAME%/admin/settings.razr'
+        'system' => 'extension://%NAME%/views/admin/settings.razr'
 
     ]
 


### PR DESCRIPTION
When using

```
pagekit extension:generate newpackage
```

The settings page of this new extension gives an error because the view is not found.
This patch fixes the default path to the view.
