### PR TITLE
Allow extensions with vendor name

### DIFF
--- a/extensions/system/src/Extension/Package/ExtensionRepository.php
+++ b/extensions/system/src/Extension/Package/ExtensionRepository.php
@@ -33,7 +33,11 @@ class ExtensionRepository extends InstalledRepository
         parent::initialize();
 
         if (empty($this->packages)) {
-            foreach (glob("{$this->path}/*/extension.json") as $config) {
+            $packages = array_merge(
+                glob("{$this->path}/*/extension.json"),
+                glob("{$this->path}/*/*/extension.json")
+            );
+            foreach ($packages as $config) {
                 $this->addPackage($this->loader->load($config));
             }
         }


### PR DESCRIPTION
With this pull request you can also build extensions with the folder order vendor/extension
Issue #164
But it lacks of compability to the generator. The *Extension.php Main file has the wrong class name.
Example:
package name -> pgnonick/test
class name -> Pgnonick/testExtension.php

Main path in extension.php is also wrong: Pgnonick\Test\Pgnonick/testExtension

Better:
class name -> TestExtension.php in the namespace Pgnonick\Test
main path in extension.php: Pgnonick\Test\TestExtension
