### PR TITLE
Fix a bug on reordering menu items

### DIFF
--- a/extensions/system/src/Menu/Controller/MenuController.php
+++ b/extensions/system/src/Menu/Controller/MenuController.php
@@ -112,7 +112,7 @@ class MenuController extends Controller
             }
 
             $item = $items[$data['id']];
-            $item->setParentId($data['parent_id']);
+            $item->setParentId($data['parent_id'] != "" ? $data['parent_id'] : "0");
             $item->setDepth($data['depth']);
             $item->setPriority($data['order']);
 

--- a/extensions/system/src/Menu/Model/Item.php
+++ b/extensions/system/src/Menu/Model/Item.php
@@ -150,10 +150,7 @@ class Item implements ItemInterface
      */
     public function setParentId($parentId)
     {
-        if ($parentId != "")
-        {
-            $this->parentId = $parentId;
-        }
+        $this->parentId = $parentId;
     }
 
     /**


### PR DESCRIPTION
Could not reorder a menu without that fix : if there was no parent_id (parent_id = "0"), then parent_id was set to "" and could not be saved
