### PR TITLE
Added new questions for create extensions and themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Pagekit
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/nbpalomino/pagekit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A modular and lightweight CMS built with Symfony components
 

--- a/extensions/system/src/System/Console/ExtensionGenerateCommand.php
+++ b/extensions/system/src/System/Console/ExtensionGenerateCommand.php
@@ -36,17 +36,23 @@ class ExtensionGenerateCommand extends Command
             exit;
         }
 
-        $title     = $this->ask('Title: ');
-        $author    = $this->ask('Author: ');
-        $email     = $this->ask('Email: ');
-        $namespace = $this->ask('PHP Namespace: ');
-        $classname = ucfirst($name).'Extension';
+        $title          = $this->ask('Title: ');
+        $description    = $this->ask('Description: ');
+        $license        = $this->ask('License: (MIT)', 'MIT');
+        $author         = $this->ask('Author: ');
+        $email          = $this->ask('Email: ');
+        $homepage       = $this->ask('Homepage: ');
+        $namespace      = $this->ask('PHP Namespace: ');
+        $classname      = ucfirst($name).'Extension';
 
         $replace = [
             '%NAME%'          => $name,
             '%TITLE%'         => $title,
+            '%DESCRIPTION%'   => $description,
+            '%LICENSE%'       => $license,
             '%AUTHOR%'        => $author,
             '%EMAIL%'         => $email,
+            '%HOMEPAGE%'      => $homepage,
             '%CLASSNAME%'     => $classname,
             '%NAMESPACE%'     => $namespace,
             '%NAMESPACE_ESC%' => addslashes($namespace)

--- a/extensions/system/src/System/Console/ThemeGenerateCommand.php
+++ b/extensions/system/src/System/Console/ThemeGenerateCommand.php
@@ -36,17 +36,23 @@ class ThemeGenerateCommand extends Command
             exit;
         }
 
-        $title     = $this->ask('Title: ');
-        $author    = $this->ask('Author: ');
-        $email     = $this->ask('Email: ');
-        $namespace = $this->ask('PHP Namespace: ');
-        $classname = ucfirst($name).'Theme';
+        $title          = $this->ask('Title: ');
+        $description    = $this->ask('Description: ');
+        $license        = $this->ask('License: (MIT)', 'MIT');
+        $author         = $this->ask('Author: ');
+        $email          = $this->ask('Email: ');
+        $homepage       = $this->ask('Homepage: ');
+        $namespace      = $this->ask('PHP Namespace: ');
+        $classname      = ucfirst($name).'Theme';
 
         $replace = [
-            '%NAME%'   => $name,
-            '%TITLE%'  => $title,
-            '%AUTHOR%' => $author,
-            '%EMAIL%'  => $email,
+            '%NAME%'          => $name,
+            '%TITLE%'         => $title,
+            '%DESCRIPTION%'   => $description,
+            '%LICENSE%'       => $license,
+            '%AUTHOR%'        => $author,
+            '%EMAIL%'         => $email,
+            '%HOMEPAGE%'      => $homepage,
             '%CLASSNAME%'     => $classname,
             '%NAMESPACE%'     => $namespace,
             '%NAMESPACE_ESC%' => addslashes($namespace)

--- a/extensions/system/src/System/Console/skeleton/extension/extension.json
+++ b/extensions/system/src/System/Console/skeleton/extension/extension.json
@@ -3,13 +3,13 @@
     "version": "0.0.1",
     "type": "extension",
     "title": "%TITLE%",
-    "description": "",
-    "license": "",
+    "description": "%DESCRIPTION%",
+    "license": "%LICENSE%",
     "authors": [
         {
             "name": "%AUTHOR%",
             "email": "%EMAIL%",
-            "homepage": ""
+            "homepage": "%HOMEPAGE%"
         }
     ]
 }

--- a/extensions/system/src/System/Console/skeleton/extension/src/DefaultExtension.php
+++ b/extensions/system/src/System/Console/skeleton/extension/src/DefaultExtension.php
@@ -5,6 +5,9 @@ namespace %NAMESPACE%;
 use Pagekit\Framework\Application;
 use Pagekit\Extension\Extension;
 
+/**
+ * %DESCRIPTION%
+ */
 class %CLASSNAME% extends Extension
 {
     /**

--- a/extensions/system/src/System/Console/skeleton/theme/src/DefaultTheme.php
+++ b/extensions/system/src/System/Console/skeleton/theme/src/DefaultTheme.php
@@ -5,6 +5,9 @@ namespace %NAMESPACE%;
 use Pagekit\Framework\Application;
 use Pagekit\Theme\Theme;
 
+/**
+ * %DESCRIPTION%
+ */
 class %CLASSNAME% extends Theme
 {
     /**

--- a/extensions/system/src/System/Console/skeleton/theme/theme.json
+++ b/extensions/system/src/System/Console/skeleton/theme/theme.json
@@ -3,13 +3,13 @@
     "version": "0.0.1",
     "type": "theme",
     "title": "%TITLE%",
-    "description": "",
-    "license": "",
+    "description": "%DESCRIPTION%",
+    "license": "%LICENSE%",
     "authors": [
         {
             "name": "%AUTHOR%",
             "email": "%EMAIL%",
-            "homepage": ""
+            "homepage": "%HOMEPAGE%"
         }
     ]
 }


### PR DESCRIPTION
### Improvement for pagekit console 

This PR just add 3 new questions:
- Description
- License (default MIT)
- Homepage

For **extension:generate** and **theme:generate** commands

![image](https://cloud.githubusercontent.com/assets/1450270/4486953/9c08f6c6-49f0-11e4-978f-1a3b2d5d4983.png)

Also add the description for `DefaultExtension.php` class

```php
 use Pagekit\Framework\Application;
 use Pagekit\Extension\Extension;
 
/**
 * %DESCRIPTION%
 */
 class %CLASSNAME% extends Extension
 {
     //--
 }
```

And for `DefaultTheme.php` class

```php
 use Pagekit\Framework\Application;
 use Pagekit\Theme\Theme;
 
/**
 * %DESCRIPTION%
 */
 class %CLASSNAME% extends Theme
 {
     //--
 }
```

PD: This is my first PR for a project... Please be comprensive... :smile: :+1: 