### PR TITLE
Fix UIKit JS not being applied

### DIFF
--- a/extensions/system/views/admin/themes/index.razr
+++ b/extensions/system/views/admin/themes/index.razr
@@ -20,7 +20,7 @@
     </div>
     <div class="uk-width-medium-3-4">
 
-        <ul id="tab-content" class="uk-switcher uk-margin">
+        <ul id="tab-content" class="uk-switcher uk-margin" data-uk-observe>
             <li>
 
                 <div class="js-installed uk-grid uk-grid-width-large-1-2" data-url="@url('@system/themes')" data-uk-grid-margin data-uk-grid-match="{target:'.uk-panel'}">


### PR DESCRIPTION
Theme updates section is loaded asynchronously and events were not being bound because of a lack of data-uk-observe attr on container element. Specifically, I noticed that the 'changelog' button was not working inside the updates tab. Wrapped all the tabs to ease further use of async content in the themes tabs.