### PR TITLE
add events to debug bar

### DIFF
--- a/app/modules/debug/app/components/events.vue
+++ b/app/modules/debug/app/components/events.vue
@@ -2,23 +2,45 @@
 
     <a title="Events"><div class="pf-icon pf-icon-events"></div> Events</a>
 
+    <script id="panel-events" type="text/template">
+
+        <h1>Events</h1>
+
+        <table class="pf-table">
+            <thead>
+                <tr>
+                    <th>Event Name</th>
+                    <th>Listener</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-repeat="events">
+                    <td>{{ name }}</td>
+                    <td><abbr title="{{ listener.details }}">{{ listener.name }}</abbr></td>
+                </tr>
+            </tbody>
+        </table>
+
+    </script>
+
 </template>
 
 <script>
 
-  module.exports = {
+    module.exports = {
 
-    section: {
-        priority: 10
-    },
+        section: {
+            priority: 20,
+            panel: '#panel-events'
+        },
 
-    props: ['data'],
+        props: ['data'],
 
-    ready: function () {
-        this.$data = this.data;
-        this.$parent.add(this);
-    }
+        ready: function () {
+            this.$data = this.data;
+            this.$parent.add(this);
+        }
 
-  };
+    };
 
 </script>

--- a/app/modules/debug/index.php
+++ b/app/modules/debug/index.php
@@ -4,6 +4,7 @@ use DebugBar\DataCollector\MemoryCollector;
 use DebugBar\DataCollector\TimeDataCollector;
 use Pagekit\Debug\DataCollector\AuthDataCollector;
 use Pagekit\Debug\DataCollector\DatabaseDataCollector;
+use Pagekit\Debug\DataCollector\EventsDataCollector;
 use Pagekit\Debug\DataCollector\RoutesDataCollector;
 use Pagekit\Debug\DataCollector\SystemDataCollector;
 use Pagekit\Debug\DebugBar;
@@ -41,6 +42,10 @@ return [
             $app['debugbar']->addCollector(new MemoryCollector());
             $app['debugbar']->addCollector(new TimeDataCollector());
             $app['debugbar']->addCollector(new RoutesDataCollector($app['router'], $app['path.cache']));
+
+            if (isset($app['events'])) {
+                $app['debugbar']->addCollector(new EventsDataCollector($app['events']));
+            }
 
             if (isset($app['auth'])) {
                 $app['debugbar']->addCollector(new AuthDataCollector($app['auth']));

--- a/app/modules/debug/src/DataCollector/EventsDataCollector.php
+++ b/app/modules/debug/src/DataCollector/EventsDataCollector.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Pagekit\Debug\DataCollector;
+
+use DebugBar\DataCollector\DataCollectorInterface;
+use Pagekit\Event\EventDispatcherInterface;
+
+class EventsDataCollector implements DataCollectorInterface
+{
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $dispatcher;
+
+    /**
+     * Constructor.
+     *
+     * @param EventDispatcherInterface $dispatcher
+     */
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect()
+    {
+        $events = [];
+        foreach ($this->dispatcher->getListeners() as $name => $listeners) {
+            foreach ($listeners as $listener) {
+                $events[] = [
+                    'name'     => $name,
+                    'listener' => $this->extractListener($listener)
+                ];
+            }
+        }
+
+        return compact('events');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'events';
+    }
+
+
+    /**
+     * @param CLosure|object|array $listener
+     *
+     * @return array|string
+     */
+    private function extractListener($listener)
+    {
+        // listener is a closure
+        if ($listener instanceof \Closure) {
+            $r = $this->reflectClosure($listener);
+
+            return [
+                'name'    => get_class($listener),
+                'details' => $r ? ($r->getFileName() . ' Line ' . $r->getStartLine()) : ''
+            ];
+        }
+
+        // listener is a concrete object
+        if (is_object($listener)) {
+            $c = get_class($listener);
+
+            return [
+                'name'    => $this->shorten($c),
+                'details' => $c
+            ];
+        }
+
+        // listener is an array of object and function
+        if (is_array($listener) && count($listener) == 2) {
+            $c = is_object($listener[0]) ? get_class($listener[0]) : $listener[0];
+
+            return [
+                'name'    => $this->shorten($c) . '::' . $listener[1],
+                'details' => $c . '::' . $listener[1]
+            ];
+        }
+
+        return ($listener);
+    }
+
+    /**
+     * @param string $object
+     *
+     * @return bool|\ReflectionFunction
+     */
+    private function reflectClosure($object)
+    {
+        try {
+            return new \ReflectionFunction($object);
+        }
+        catch (\ReflectionException $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param string $className
+     *
+     * @return string
+     */
+    private function shorten($className)
+    {
+        return array_slice(explode('\\', $className), -1)[0];
+    }
+
+}

--- a/app/modules/debug/src/DataCollector/EventsDataCollector.php
+++ b/app/modules/debug/src/DataCollector/EventsDataCollector.php
@@ -52,7 +52,7 @@ class EventsDataCollector implements DataCollectorInterface
 
 
     /**
-     * @param CLosure|object|array $listener
+     * @param Closure|object|array $listener
      *
      * @return array|string
      */


### PR DESCRIPTION
I was trying to bring back the events tab to the debug-bar. This solution is working, but I am not sure, if there is an easier way to get a nice output of the listener itself, because it can be registered as closure, object or array (with object or string). Let me know, what you think.