### PR TITLE
check for property

### DIFF
--- a/app/modules/database/src/ORM/PropertyTrait.php
+++ b/app/modules/database/src/ORM/PropertyTrait.php
@@ -134,7 +134,7 @@ trait PropertyTrait
             return static::$_properties[$name];
         }
 
-        if (isset(static::$properties[$name])) {
+        if (isset(static::$properties) && isset(static::$properties[$name])) {
             return static::defineProperty($name, static::$properties[$name]);
         }
     }


### PR DESCRIPTION
If model has no `properties`, `Fatal error: Access to undeclared static property` is thrown