### PR TITLE
force integer for lastInsertId()

### DIFF
--- a/app/modules/database/src/ORM/EntityManager.php
+++ b/app/modules/database/src/ORM/EntityManager.php
@@ -155,7 +155,7 @@ class EntityManager
 
             $this->connection->insert($metadata->getTable(), $metadata->getValues($entity, true, true));
 
-            $metadata->setValue($entity, $identifier, $this->connection->lastInsertId(), true);
+            $metadata->setValue($entity, $identifier, (int) $this->connection->lastInsertId(), true);
 
             $this->trigger(Events::CREATED, $metadata, [$entity, $data]);
 


### PR DESCRIPTION
When adding a Widget, the `lastInserId` of the widget is returned as a string. This causes a string to be written in the position config of the theme. This causes no problem on the frontend, the widget is positioned correctly. In the admin, the js places the module in the 'unassigned' category.
![id_string](https://cloud.githubusercontent.com/assets/5442402/9027014/a0b0f75c-3944-11e5-84eb-8552b59eb62d.png)
![unassigned](https://cloud.githubusercontent.com/assets/5442402/9027015/a2976f7e-3944-11e5-892d-9a70006130cf.png)
![string_saved](https://cloud.githubusercontent.com/assets/5442402/9027016/a486cc1c-3944-11e5-8844-b6abbd6585e9.png)
This is fixed when saving the widget again, when the id is an integer.
![after_edit](https://cloud.githubusercontent.com/assets/5442402/9027017/ad00e3dc-3944-11e5-827e-6f35526819cc.png)

