### PR TITLE
Slug filter

### DIFF
--- a/app/modules/filter/src/FilterManager.php
+++ b/app/modules/filter/src/FilterManager.php
@@ -18,6 +18,7 @@ class FilterManager
         'integer'        => 'Pagekit\Filter\Int',
         'json'           => 'Pagekit\Filter\Json',
         'pregreplace'    => 'Pagekit\Filter\PregReplace',
+        'slug'           => 'Pagekit\Filter\Slug',
         'string'         => 'Pagekit\Filter\String',
         'stripnewlines'  => 'Pagekit\Filter\StripNewlines'
     ];

--- a/app/modules/filter/src/Slug.php
+++ b/app/modules/filter/src/Slug.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Pagekit\Filter;
+
+/**
+ * This filter generates the slug of the given value.
+ */
+class Slug extends AbstractFilter
+{
+    /**
+     * @inheritdoc
+     */
+    public function filter($value)
+    {
+        // replace ideographic space with space
+        $value = preg_replace('/\xE3\x80\x80/', ' ', $value);
+        // replace dash with space
+        $value = str_replace('-', ' ', $value);
+        // replace special characters with space
+        $value = preg_replace('#[:\#\*"@+=;!><&\.%()\]\/\'\\\\|\[]#', "\x20", $value);
+        // remove interrogation mark
+        $value = str_replace('?', '', $value);
+        // make lowercase, remove spaces at the beginning and end
+        $value = trim(mb_strtolower($value, 'UTF-8'));
+        // replace every single or series of spaces with a single dash
+        $value = preg_replace('#\x20+#', '-', $value);
+
+        return $value;
+    }
+}

--- a/app/modules/filter/src/Tests/SlugTest.php
+++ b/app/modules/filter/src/Tests/SlugTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Pagekit\Filter\Tests;
+
+use Pagekit\Filter\Slug;
+
+class SlugTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testFilter()
+    {
+        $filter = new Slug;
+
+        $values = [
+            'PAGEKIT'                  => 'pagekit',
+            ":#*\"@+=;!><&.%()/'\\|[]" => "",
+            "  a b ! c   "             => "a-b-c",
+        ];
+
+        foreach ($values as $in => $out) {
+            $this->assertEquals($out, $filter->filter($in));
+        }
+
+    }
+
+}

--- a/extensions/blog/src/Controller/PostApiController.php
+++ b/extensions/blog/src/Controller/PostApiController.php
@@ -80,7 +80,7 @@ class PostApiController
             $post = Post::create();
         }
 
-        if (!$data['slug'] = $this->slugify($data['slug'] ?: $data['title'])) {
+        if (!$data['slug'] = App::filter()->get('slug')->filter($data['slug'] ?: $data['title'])) {
             App::abort(400, __('Invalid slug.'));
         }
 
@@ -168,15 +168,4 @@ class PostApiController
         return ['message' => 'success'];
     }
 
-    protected function slugify($slug)
-    {
-        $slug = preg_replace('/\xE3\x80\x80/', ' ', $slug);
-        $slug = str_replace('-', ' ', $slug);
-        $slug = preg_replace('#[:\#\*"@+=;!><&\.%()\]\/\'\\\\|\[]#', "\x20", $slug);
-        $slug = str_replace('?', '', $slug);
-        $slug = trim(mb_strtolower($slug, 'UTF-8'));
-        $slug = preg_replace('#\x20+#', '-', $slug);
-
-        return $slug;
-    }
 }


### PR DESCRIPTION
As mentioned in #398 here is the PR for a slug filter. Tested and working.

As I wrote the tests, I was wondering, why this filter cannot handle special language-specific characters like the German äöü and others. Wouldn't a slug filter be responsible for handling this, too? I would expect it. Here is a slugify package that does it.

https://github.com/cocur/slugify

Perhaps we should consider using it or adjust our slug filter to support more special characters.