### PR TITLE
fix login widget

### DIFF
--- a/app/system/modules/user/app/components/widget-login.vue
+++ b/app/system/modules/user/app/components/widget-login.vue
@@ -41,7 +41,7 @@
 
         section: {
             label: 'Settings',
-            active: 'system/widget-login',
+            active: 'system/login',
             priority: 0
         },
 


### PR DESCRIPTION
Settings tab was not showing in widget edit