### PR TITLE
fix problem with insecure content by using https

### DIFF
--- a/app/system/modules/dashboard/app/components/widget-location.vue
+++ b/app/system/modules/dashboard/app/components/widget-location.vue
@@ -60,7 +60,7 @@
 
 <script>
 
-    var api = 'http://api.openweathermap.org/data/2.5';
+    var api = '//api.openweathermap.org/data/2.5';
 
     module.exports = {
 

--- a/app/system/modules/dashboard/app/components/widget-location.vue
+++ b/app/system/modules/dashboard/app/components/widget-location.vue
@@ -60,7 +60,7 @@
 
 <script>
 
-    var api = '//api.openweathermap.org/data/2.5';
+    var api = 'https://api.openweathermap.org/data/2.5';
 
     module.exports = {
 


### PR DESCRIPTION
On a https enforced pagekit there is a problem with the weather/location widget. You can't change the location because of an unsecure connection to api.openweathermap.org.