### PR TITLE
Get translation strings from *.html

### DIFF
--- a/app/console/src/Commands/ExtensionTranslateCommand.php
+++ b/app/console/src/Commands/ExtensionTranslateCommand.php
@@ -183,7 +183,7 @@ class ExtensionTranslateCommand extends Command
             $files->in($this->container->path().'/app/installer');
         }
 
-        return $files->name('*.{php,vue,js}');
+        return $files->name('*.{php,vue,js,html}');
     }
 
     /**


### PR DESCRIPTION
When using partial html templates translation command does not extract strings from *.html. This PR will fix it.