### PR TITLE
Logical operators (and) should be avoided

### DIFF
--- a/app/system/modules/site/src/Model/NodeModelTrait.php
+++ b/app/system/modules/site/src/Model/NodeModelTrait.php
@@ -99,7 +99,7 @@ trait NodeModelTrait
 
         // Update own path
         $path = '/'.$node->slug;
-        if ($node->parent_id && $parent = Node::find($node->parent_id) and $parent->menu == $node->menu) {
+        if ($node->parent_id && $parent = Node::find($node->parent_id) && $parent->menu == $node->menu) {
             $path = $parent->path.$path;
         } else {
             // set Parent to 0, if old parent is not found


### PR DESCRIPTION
The and operator does not have the same precedence as &&.
This could lead to unexpected behavior, so I change to && instead.