### PR TITLE
Add gulp-plumber to prevent pipe from breaking on compile error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var merge = require('merge-stream'),
     less = require('gulp-less'),
     rename = require('gulp-rename'),
     eslint = require('gulp-eslint'),
+    plumber = require('gulp-plumber'),
     fs = require('fs'),
     path = require('path');
 
@@ -32,6 +33,12 @@ var cldr = {
     languages: path.join(__dirname, 'app/system/languages/')
 };
 
+// general error handler for plumber
+var errhandler = function (error) {
+    this.emit('end');
+    return console.error(error.toString());
+};
+
 gulp.task('default', ['compile']);
 
 /**
@@ -45,6 +52,7 @@ gulp.task('compile', function () {
 
     return merge.apply(null, pkgs.map(function (pkg) {
         return gulp.src(pkg.path + '**/less/*.less', {base: pkg.path})
+            .pipe(plumber(errhandler))
             .pipe(less({compress: true, relativeUrls: true}))
             .pipe(header(banner, {data: require('./' + pkg.path + pkg.data)}))
             .pipe(rename(function (file) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-eslint": "^0.7.0",
     "gulp-header": "^1.2.2",
     "gulp-less": "^3.0.0",
+    "gulp-plumber": "^1.0.1",
     "gulp-rename": "^1.2.0",
     "gulp-util": "^3.0.4",
     "json-loader": "^0.5.2",


### PR DESCRIPTION
Currently, when running the `gulp watch` task, a syntax error in one of the source files causes the watch task to break and the task has to be cancelled and restarted.

With this update, an error will just terminate the current pipe but allow the compile task to run properly the next time there are file changes.

### Before

<img width="571" alt="screen shot 2015-12-27 at 12 30 05" src="https://cloud.githubusercontent.com/assets/1693461/12011332/fb5d54a0-ac96-11e5-8cd3-d69f85633667.png">

### After

<img width="571" alt="screen shot 2015-12-27 at 12 31 06" src="https://cloud.githubusercontent.com/assets/1693461/12011333/ff121ff4-ac96-11e5-83bc-c2c971638e86.png">
