### PR TITLE
Filling the parameter $version

### DIFF
--- a/app/console/app.php
+++ b/app/console/app.php
@@ -27,5 +27,5 @@ if ($app['config.file']) {
 }
 $app['module']->load('console');
 
-$console = new Console($app, 'Pagekit');
+$console = new Console($app, 'Pagekit', $app->version());
 $console->run();


### PR DESCRIPTION
 Filling the parameter version expected by the parent constructor, otherwise the default value of the $version will be always 'UNKNOWN' (default value)