### PR TITLE
Add config to props

### DIFF
--- a/app/system/modules/widget/app/components/widget-settings.vue
+++ b/app/system/modules/widget/app/components/widget-settings.vue
@@ -29,7 +29,7 @@
             label: 'Settings'
         },
 
-        props: ['widget', 'form'],
+        props: ['widget', 'form', 'config'],
 
         created: function () {
             this.$options.partials = this.$parent.$options.partials;


### PR DESCRIPTION
default widget settings had no config object for roles and positions.

Solves https://github.com/Bixie/pagekit-breadcrumbs/issues/1