### PR TITLE
limit directory depth file info

### DIFF
--- a/app/system/modules/info/src/InfoHelper.php
+++ b/app/system/modules/info/src/InfoHelper.php
@@ -60,7 +60,7 @@ class InfoHelper
             $result[$this->getRelativePath($directory)] = is_writable($directory);
 
             if (is_dir($directory)) {
-                foreach (App::finder()->in($directory)->directories() as $dir) {
+                foreach (App::finder()->depth('< 2')->in($directory)->directories() as $dir) {
                     if (!is_writable($dir->getPathname())) {
                         $result[$this->getRelativePath($dir->getPathname())] = false;
                     }


### PR DESCRIPTION
My machine was timing out on the many packages and their dependancies I have installed. The system/info page and deburbar become unuseable. In some of them there is a node_modules folder, which takes a lot of time to traverse.
With `->depth('< 2')` you check the packages folder itself, but not its contents.
I don't think checking storage and cache only 2 levels deep will be bad either.
