### PR TITLE
Change from composer update to composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you've set up Pagekit from source, run these commands to get new commits and 
 
 ```
 git pull
-composer update
+composer install
 npm install
 ```
 


### PR DESCRIPTION
Thanks for contributing. Please check the following points before submitting your pull request. Thank you!

- [x] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x] The destination branch of the pull request is the `develop` branch
Hello,

since the repo contains the composer.lock file,
I think it would be better for peolple to use install, instead of update, so they get same versions of all packages like the last commit. 
And those who feel strong! can always run update (they probably know the difference).

Thanks