### PR TITLE
Ogimage fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## WIP
+- Fixed exception when no og:image
 
 ### Added
 - Added OpenGraph image option for site nodes

--- a/app/system/modules/site/index.php
+++ b/app/system/modules/site/index.php
@@ -185,10 +185,9 @@ return [
                     'og:url' => $meta->get('canonical'),
                 ]);
 
-                if ($app['node']->get('meta')) {
-                    $config = $app['node']->get('meta');
+				if ($config = $app['node']->get('meta')) {
 
-                    if ($config['og:image']) {
+					if (!empty($config['og:image'])) {
                         $config['og:image'] = $app['url']->getStatic($config['og:image'], [], 0);
                     }
 


### PR DESCRIPTION
Was thrown when title/descr but no image is set on the meta-data of node

Reported by @CopelReparatie in Gitter


- [x] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x] The destination branch of the pull request is the `develop` branch
Was thrown when title/descr but no image is set on the meta-data of node