### PR TITLE
fix argument ordering

### DIFF
--- a/app/system/modules/mail/src/Message.php
+++ b/app/system/modules/mail/src/Message.php
@@ -109,11 +109,11 @@ class Message extends Swift_Message implements MessageInterface
 	 * Prepare and attach the given attachment.
 	 *
 	 * @param  Swift_Mime_Attachment $attachment
-	 * @param  string                $mime
-     * @param  string                $name
+	 * @param  string                $name
+     * @param  string                $mime
 	 * @return self
 	 */
-	protected function prepareAttachment(Swift_Mime_Attachment $attachment, $mime = null, $name = null)
+	protected function prepareAttachment(Swift_Mime_Attachment $attachment, $name = null, $mime = null)
 	{
 		if (null !== $mime) {
 			$attachment->setContentType($mime);


### PR DESCRIPTION
To match the function calls from `attachFile` and `attachData` and their signature

- [x] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x] The destination branch of the pull request is the `develop` branch
to match the function calls from `attachFile` and `attachData` and their signature