### PR TITLE
Fix "install Pagekit from source" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pagekit is a modular and lightweight CMS built with Symfony components and Vue.j
 
 ## Install from source
 
-If you want to run the current development version, you can [install Pagekit from source](https://pagekit.com/docs/developer-basics/source).
+If you want to run the current development version, you can [install Pagekit from source](https://pagekit.com/docs/developer/source).
 
 ## CLI
 


### PR DESCRIPTION
Fix "install Pagekit from source" link in README.md.

- [x] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x] The destination branch of the pull request is the `develop` branch
