### PR TITLE
Button group functionality

### DIFF
--- a/app/system/app/components/button-checkbox.vue
+++ b/app/system/app/components/button-checkbox.vue
@@ -1,0 +1,53 @@
+<template>
+    <div :class="modifier">
+        <label type="button" class="uk-button" v-for="option in options" :class="getButtonClass($index)"><input type="checkbox" style="display: none;" v-model="field" :value="option.value" :disabled="disabled || option.disabled" /> {{ option.label | trans }}</label>
+    </div>
+</template>
+<script>
+    module.exports = {
+
+        props: {
+            field: {
+                type: [Array],
+                twoWay: true
+            },
+            options: [Array, Object],
+            modifier: [String, Function],
+            button: {
+                type: [String, Function],
+                default: ''
+            },
+            active: [String, Function],
+            disabled: {
+                type: Boolean,
+                default: false
+            }
+        },
+
+        ready: function () {
+
+        },
+
+        methods: {
+            getButtonClass: function (index) {
+                var button_class = this.button.split(' ');
+
+                if (this.field.indexOf(this.options[index].value) !== -1) {
+                    button_class.push('uk-button');
+                    button_class.push('uk-active');
+                    if(this.active) {
+                        button_class.push(this.active);
+                    }
+                } else {
+                    button_class.push('uk-button');
+                }
+
+                return button_class;
+            }
+        }
+    };
+
+    Vue.component('button-checkbox', function (resolve) {
+        resolve(module.exports);
+    });
+</script>

--- a/app/system/app/components/button-checkbox.vue
+++ b/app/system/app/components/button-checkbox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="modifier">
+    <div :class="classes">
         <label type="button" class="uk-button" v-for="option in options" :class="getButtonClass($index)"><input type="checkbox" style="display: none;" v-model="field" :value="option.value" :disabled="disabled || option.disabled" /> {{ option.label | trans }}</label>
     </div>
 </template>
@@ -43,6 +43,16 @@
                 }
 
                 return button_class;
+            }
+        },
+
+        computed: {
+            classes: function () {
+                var classes = this.modifier.split(' ');
+
+                classes.push('uk-button-group')
+
+                return classes;
             }
         }
     };

--- a/app/system/app/components/button-radio.vue
+++ b/app/system/app/components/button-radio.vue
@@ -1,0 +1,53 @@
+<template>
+    <div :class="modifier">
+        <label type="button" class="uk-button" v-for="option in options" :class="getButtonClass($index)"><input type="radio" style="display: none;" v-model="field" :value="option.value" :disabled="disabled || option.disabled" /> {{ option.label | trans }}</label>
+    </div>
+</template>
+<script>
+    module.exports = {
+
+        props: {
+            field: {
+                type: [String, Number],
+                twoWay: true
+            },
+            options: [Object, Array],
+            modifier: [String, Function],
+            button: {
+                type: [String, Function],
+                default: ''
+            },
+            active: [String, Function],
+            disabled: {
+                type: Boolean,
+                default: false
+            }
+        },
+
+        ready: function () {
+
+        },
+
+        methods: {
+            getButtonClass: function (index) {
+                var button_class = this.button.split(' ');
+
+                if (this.options[index].value == this.field) {
+                    button_class.push('uk-button');
+                    button_class.push('uk-active');
+                    if(this.active) {
+                        button_class.push(this.active);
+                    }
+                } else {
+                    button_class.push('uk-button');
+                }
+
+                return button_class;
+            }
+        }
+    };
+
+    Vue.component('button-radio', function (resolve) {
+        resolve(module.exports);
+    });
+</script>

--- a/app/system/app/components/button-radio.vue
+++ b/app/system/app/components/button-radio.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="modifier">
+    <div :class="classes">
         <label type="button" class="uk-button" v-for="option in options" :class="getButtonClass($index)"><input type="radio" style="display: none;" v-model="field" :value="option.value" :disabled="disabled || option.disabled" /> {{ option.label | trans }}</label>
     </div>
 </template>
@@ -43,6 +43,16 @@
                 }
 
                 return button_class;
+            }
+        },
+
+        computed: {
+            classes: function () {
+                var classes = this.modifier.split(' ');
+
+                classes.push('uk-button-group');
+
+                return classes;
             }
         }
     };

--- a/app/system/app/vue.js
+++ b/app/system/app/vue.js
@@ -47,6 +47,8 @@ function install (Vue) {
     Vue.component('v-pagination', require('./components/pagination'));
     Vue.component('input-filter', require('./components/input-filter.vue'));
 
+    require('./components/button-radio.vue');
+    require('./components/button-checkbox.vue');
     require('./components/input-date.vue');
     require('./components/input-image.vue');
     require('./components/input-image-meta.vue');

--- a/app/system/modules/user/app/components/user-settings.vue
+++ b/app/system/modules/user/app/components/user-settings.vue
@@ -43,14 +43,14 @@
             <div class="uk-form-row">
                 <span class="uk-form-label">{{ 'Status' | trans }}</span>
                 <div class="uk-form-controls">
-                    <button-radio :field.sync="user.status" :options="statuses" modifier="uk-button-group uk-form-width-large" button="uk-width-1-2" :active="user.status == 1 ? 'uk-button-success' : 'uk-button-danger'" :disabled="config.currentUser == user.id"></button-radio>
+                    <button-radio :field.sync="user.status" :options="statuses" modifier="uk-form-width-large" button="uk-width-1-2" :active="user.status == 1 ? 'uk-button-success' : 'uk-button-danger'" :disabled="config.currentUser == user.id"></button-radio>
                 </div>
             </div>
 
             <div class="uk-form-row">
                 <span class="uk-form-label">{{ 'Roles' | trans }}</span>
                 <div class="uk-form-controls" v-if="config.roles.length <= 3">
-                    <button-checkbox :field.sync="user.roles" :options="roles" modifier="uk-button-group uk-form-width-large" :button="'uk-width-1-'+config.roles.length"></button-checkbox>
+                    <button-checkbox :field.sync="user.roles" :options="roles" modifier="uk-form-width-large" :button="'uk-width-1-'+config.roles.length"></button-checkbox>
                 </div>
                 <div class="uk-form-controls uk-form-controls-text" v-else>
                     <p class="uk-form-controls-condensed" v-for="role in config.roles">

--- a/app/system/modules/user/app/components/user-settings.vue
+++ b/app/system/modules/user/app/components/user-settings.vue
@@ -42,16 +42,17 @@
 
             <div class="uk-form-row">
                 <span class="uk-form-label">{{ 'Status' | trans }}</span>
-                <div class="uk-form-controls uk-form-controls-text">
-                    <p class="uk-form-controls-condensed" v-for="status in config.statuses">
-                        <label><input type="radio" v-model="user.status" :value="parseInt($key)" :disabled="config.currentUser == user.id"> {{ status }}</label>
-                    </p>
+                <div class="uk-form-controls">
+                    <button-radio :field.sync="user.status" :options="statuses" modifier="uk-button-group uk-form-width-large" button="uk-width-1-2" :active="user.status == 1 ? 'uk-button-success' : 'uk-button-danger'" :disabled="config.currentUser == user.id"></button-radio>
                 </div>
             </div>
 
             <div class="uk-form-row">
                 <span class="uk-form-label">{{ 'Roles' | trans }}</span>
-                <div class="uk-form-controls uk-form-controls-text">
+                <div class="uk-form-controls" v-if="config.roles.length <= 3">
+                    <button-checkbox :field.sync="user.roles" :options="roles" modifier="uk-button-group uk-form-width-large" :button="'uk-width-1-'+config.roles.length" :active="user.status == 1 ? 'uk-button-success' : 'uk-button-danger'"></button-checkbox>
+                </div>
+                <div class="uk-form-controls uk-form-controls-text" v-else>
                     <p class="uk-form-controls-condensed" v-for="role in config.roles">
                         <label><input type="checkbox" :value="role.id" :disabled="role.disabled" v-model="user.roles"> {{ role.name }}</label>
                     </p>
@@ -116,13 +117,33 @@
         },
 
         ready: function () {
-    
+
         },
 
         computed: {
 
             isNew: function () {
                 return !this.user.login && this.user.status;
+            },
+
+            statuses: function () {
+                var statuses = [], vm = this;
+
+                $.each(vm.config.statuses, function (index, value) {
+                    statuses.push({ label: value, value: index });
+                });
+
+                return statuses;
+            },
+
+            roles: function () {
+                var roles = [], vm = this;
+
+                $.each(vm.config.roles, function (key, value) {
+                    roles.push({ label: value.name, value: value.id, disabled: value.disabled });
+                });
+
+                return roles;
             }
 
         },

--- a/app/system/modules/user/app/components/user-settings.vue
+++ b/app/system/modules/user/app/components/user-settings.vue
@@ -50,7 +50,7 @@
             <div class="uk-form-row">
                 <span class="uk-form-label">{{ 'Roles' | trans }}</span>
                 <div class="uk-form-controls" v-if="config.roles.length <= 3">
-                    <button-checkbox :field.sync="user.roles" :options="roles" modifier="uk-button-group uk-form-width-large" :button="'uk-width-1-'+config.roles.length" :active="user.status == 1 ? 'uk-button-success' : 'uk-button-danger'"></button-checkbox>
+                    <button-checkbox :field.sync="user.roles" :options="roles" modifier="uk-button-group uk-form-width-large" :button="'uk-width-1-'+config.roles.length"></button-checkbox>
                 </div>
                 <div class="uk-form-controls uk-form-controls-text" v-else>
                     <p class="uk-form-controls-condensed" v-for="role in config.roles">


### PR DESCRIPTION
I always thought the button radios and checkboxes in Joomla were a nice touch to the admin. And I've been using this functionality on the custom extensions for Pagekit I've been making. So, I thought it might be a nice addition to Pagekit.

![screen shot 2016-07-10 at 1 57 54 am](https://cloud.githubusercontent.com/assets/19509971/16712383/fc08466c-4642-11e6-8eaa-e850b64a5119.png)
![screen shot 2016-07-10 at 1 58 21 am](https://cloud.githubusercontent.com/assets/19509971/16712382/fc08251a-4642-11e6-9ef3-c94e8cf9827c.png)

## Usage:

Anywhere Vue is mounted:

`<button-radio :field.sync="field.object" :options="[ { label: 'Label 1', value: 1}, { label: 'Label 2', value: 2} ]" modifier="css-class-modifier-for-parent" button="css-class-modifier-for-buttons" active="css-class-modifier-for-active-buttons"></button-radio>`

### Options

    field: {
        type: [String, Number],
        twoWay: true
    },
    options: [Object, Array],
    modifier: [String, Function],
    button: {
        type: [String, Function],
        default: ''
    },
    active: [String, Function],
    disabled: {
        type: Boolean,
        default: false
    }

<button-checkbox :field.sync="field.object" :options="[ { label: 'Label 1', value: 1}, { label: 'Label 2', value: 2} ]" modifier="css-class-modifier-for-parent" button="css-class-modifier-for-buttons" active="css-class-modifier-for-active-buttons"></button-checkbox>

### Options

    field: {
        type: [Array],
        twoWay: true
    },
    options: [Array, Object],
    modifier: [String, Function],
    button: {
        type: [String, Function],
        default: ''
    },
    active: [String, Function],
    disabled: {
        type: Boolean,
        default: false
    }

With these props, you are able to have a greater degree of control over the styling of the button group. I've included a demo of usage in the user-settings.vue component that serves as the user editor in the backend.

## Dev stuff:

I was originally using UIkit.buttonRadio and UIkit.buttonCheckbox, for example:

    this.radio = UIkit.buttonRadio(this.$els.radio, {});

    var vm = this;
    $(vm.$els.radio).on('change.uk.button', function (e) {
        vm.field = vm.radio.getSelected().val();
    });

However, both jQuery and just regular javascript always returned strings for the field values; whereas Vue.js supports multiple variable types (int, string, float, etc). Setting a reactive Vue field in this way made things funny and inconsistent.

So, instead of trying to work around that, we can just wrap the `<input>` in a `<label>` element and have Vue continue to do it's magic and keep browser compatibility.

When working on the user-settings.vue, I noticed that there was some dynamic nature for :disabled attributes, and included those with these two new component. You can either outright disable all fields via a component prop, or disable individual fields by including a disabled: true property in your options.

- [x] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x] The destination branch of the pull request is the `develop` branch