### PR TITLE
Console Modules/Extensions

### DIFF
--- a/app/modules/application/src/Application/Console/Application.php
+++ b/app/modules/application/src/Application/Console/Application.php
@@ -32,6 +32,13 @@ class Application extends BaseApplication
 
         $this->container = $container;
 
+        $manager = $container['module'];
+        $toLoad = $manager->getType('console');
+
+        foreach ($toLoad as $module) {
+            $manager->load($module);
+        }
+
         if (isset($container['events'])) {
             $container['events']->trigger('console.init', [$this]);
         }

--- a/app/modules/application/src/Module/ModuleManager.php
+++ b/app/modules/application/src/Module/ModuleManager.php
@@ -77,6 +77,23 @@ class ModuleManager implements \IteratorAggregate
     }
 
     /**
+     * Gets all modules of a specific type
+     *
+     * @param string $type
+     * @return array
+     */
+    public function getType($type)
+    {
+        $modules = [];
+        foreach ($this->registered as $module) {
+            if (isset($module['type']) && $module['type'] === $type) {
+                $modules[] = $module['name'];
+            }
+        }
+        return $modules;
+    }
+
+    /**
      * Gets all modules.
      *
      * @return array


### PR DESCRIPTION
This request is to allow any module with a type of 'console' to be loaded into the application before the 'console.init' event is called, but also allows for future development by adding a `getType` function in the module manager that returns any registered modules of a specific type.

Currently modules don't get loaded before the 'console.init' event is called and this is limiting if you want to build a pagekit extension/module that extends the pagekit console.

- [x] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x] The destination branch of the pull request is the `develop` branch