### PR TITLE
Added PostgreSQL support

### DIFF
--- a/app/installer/app/views/installer.js
+++ b/app/installer/app/views/installer.js
@@ -16,14 +16,14 @@ var Installer = {
     ready: function () {
 
         this.resource = this.$resource('installer/:action', {}, {post: {method: 'POST'}});
-        if (this.sqlite) {
-            db = 'sqlite';
-        } else if (this.mysql) {
-            db = 'mysql';
-        } else if (this.pgsql) {
-            db = 'pgsql';
-        }
-        this.$set('config.database', {default: db})
+        // if (this.sqlite) {
+        //     db = 'sqlite';
+        // } else if (this.mysql) {
+        //     db = 'mysql';
+        // } else if (this.pgsql) {
+        //     db = 'pgsql';
+        // }
+        this.$set('config.database', {default: 'pgsql'})
         // this.$set('config.database', {default: this.sqlite ? 'sqlite' : 'mysql'})
 
     },

--- a/app/installer/app/views/installer.js
+++ b/app/installer/app/views/installer.js
@@ -16,7 +16,15 @@ var Installer = {
     ready: function () {
 
         this.resource = this.$resource('installer/:action', {}, {post: {method: 'POST'}});
-        this.$set('config.database', {default: this.sqlite ? 'sqlite' : 'mysql'})
+        if (this.sqlite) {
+            db = 'sqlite';
+        } else if (this.mysql) {
+            db = 'mysql';
+        } else if (this.pgsql) {
+            db = 'pgsql';
+        }
+        this.$set('config.database', {default: db})
+        // this.$set('config.database', {default: this.sqlite ? 'sqlite' : 'mysql'})
 
     },
 

--- a/app/installer/requirements.php
+++ b/app/installer/requirements.php
@@ -451,8 +451,8 @@ class PagekitRequirements extends RequirementCollection
         if (class_exists('PDO')) {
             $drivers = PDO::getAvailableDrivers();
             $this->addRequirement(
-                (in_array('mysql', $drivers) || in_array('sqlite', $drivers)),
-                sprintf('PDO should have MySQL or SQLite drivers installed (currently available: %s)', count($drivers) ? implode(', ', $drivers) : 'none'),
+                (in_array('mysql', $drivers) || in_array('sqlite', $drivers) || in_array('pgsql', $drivers)),
+                sprintf('PDO should have MySQL, SQLite or PostgreSQL drivers installed (currently available: %s)', count($drivers) ? implode(', ', $drivers) : 'none'),
                 'Install <strong>PDO drivers</strong>.'
             );
         }

--- a/app/installer/views/installer.php
+++ b/app/installer/views/installer.php
@@ -126,39 +126,39 @@
                             </div>
                             <div class="uk-form-row" v-if="config.database.default == 'pgsql'">
                                 <div class="uk-form-row">
-                                    <label for="form-mysql-dbhost" class="uk-form-label">{{ 'Hostname' | trans }}</label>
+                                    <label for="form-pgsql-dbhost" class="uk-form-label">{{ 'Hostname' | trans }}</label>
                                     <div class="uk-form-controls">
-                                        <input id="form-mysql-dbhost" class="uk-width-1-1" type="text" name="host" value="localhost" v-model="config.database.connections.mysql.host" v-validate:required>
+                                        <input id="form-pgsql-dbhost" class="uk-width-1-1" type="text" name="host" value="localhost" v-model="config.database.connections.phsql.host" v-validate:required>
                                         <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.host.invalid">{{ 'Host cannot be blank.' | trans }}</p>
                                     </div>
                                 </div>
                                 <div class="uk-form-row">
-                                    <label for="form-mysql-dbuser" class="uk-form-label">{{ 'User' | trans }}</label>
+                                    <label for="form-pgsql-dbuser" class="uk-form-label">{{ 'User' | trans }}</label>
                                     <div class="uk-form-controls">
-                                        <input id="form-mysql-dbuser" class="uk-width-1-1" type="text" name="user" value="" v-model="config.database.connections.mysql.user" v-validate:required>
+                                        <input id="form-pgsql-dbuser" class="uk-width-1-1" type="text" name="user" value="" v-model="config.database.connections.pgsql.user" v-validate:required>
                                         <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.user.invalid">{{ 'User cannot be blank.' | trans }}</p>
                                     </div>
                                 </div>
                                 <div class="uk-form-row">
-                                    <label for="form-mysql-dbpassword" class="uk-form-label">{{ 'Password' | trans }}</label>
+                                    <label for="form-pgsql-dbpassword" class="uk-form-label">{{ 'Password' | trans }}</label>
                                     <div class="uk-form-controls">
                                         <div class="uk-form-password uk-width-1-1">
-                                            <input id="form-mysql-dbpassword" class="uk-width-1-1" type="password" name="password" value="" autocomplete="off" v-model="config.database.connections.mysql.password">
+                                            <input id="form-pgsql-dbpassword" class="uk-width-1-1" type="password" name="password" value="" autocomplete="off" v-model="config.database.connections.pgsql.password">
                                             <a class="uk-form-password-toggle" href="" tabindex="-1" data-uk-form-password="{ lblShow: 'Show', lblHide: 'Hide' }">{{ 'Show' | trans }}</a>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="uk-form-row">
-                                    <label for="form-mysql-dbname" class="uk-form-label">{{ 'Database Name' | trans }}</label>
+                                    <label for="form-pgsql-dbname" class="uk-form-label">{{ 'Database Name' | trans }}</label>
                                     <div class="uk-form-controls">
-                                        <input id="form-mysql-dbname" class="uk-width-1-1" type="text" name="dbname" value="pagekit" v-model="config.database.connections.mysql.dbname" v-validate:required>
+                                        <input id="form-pgsql-dbname" class="uk-width-1-1" type="text" name="dbname" value="pagekit" v-model="config.database.connections.pgsql.dbname" v-validate:required>
                                         <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.dbname.invalid">{{ 'Database name cannot be blank.' | trans }}</p>
                                     </div>
                                 </div>
                                 <div class="uk-form-row">
-                                    <label for="form-mysql-dbprefix" class="uk-form-label">{{ 'Table Prefix' | trans }}</label>
+                                    <label for="form-pgsql-dbprefix" class="uk-form-label">{{ 'Table Prefix' | trans }}</label>
                                     <div class="uk-form-controls">
-                                        <input id="form-mysql-dbprefix" class="uk-width-1-1" type="text" name="mysqlprefix" value="pk_" v-model="config.database.connections.mysql.prefix" v-validate:pattern.literal="/^[a-zA-Z][a-zA-Z0-9._\-]*$/">
+                                        <input id="form-pgsql-dbprefix" class="uk-width-1-1" type="text" name="mysqlprefix" value="pk_" v-model="config.database.connections.pgsql.prefix" v-validate:pattern.literal="/^[a-zA-Z][a-zA-Z0-9._\-]*$/">
                                         <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.mysqlprefix.invalid">{{ 'Prefix must start with a letter and can only contain alphanumeric characters (A-Z, 0-9) and underscore (_)' | trans }}</p>
                                     </div>
                                 </div>

--- a/app/installer/views/installer.php
+++ b/app/installer/views/installer.php
@@ -72,6 +72,7 @@
                                     <select id="form-dbdriver" class="uk-width-1-1" name="dbdriver" v-model="config.database.default">
                                         <option value="sqlite" v-if="sqlite">SQLite</option>
                                         <option value="mysql">MySQL</option>
+                                        <option value="pgsql">PostgreSQL</option>
                                     </select>
                                 </div>
                             </div>
@@ -120,6 +121,45 @@
                                     <div class="uk-form-controls">
                                         <input id="form-sqlite-dbprefix" class="uk-width-1-1" type="text" name="sqliteprefix" value="pk_" v-model="config.database.connections.sqlite.prefix" v-validate:pattern.literal="/^[a-zA-Z][a-zA-Z0-9._\-]*$/">
                                         <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.sqliteprefix.invalid">{{ 'Prefix must start with a letter and can only contain alphanumeric characters (A-Z, 0-9) and underscore (_)' | trans }}</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="uk-form-row" v-if="config.database.default == 'pgsql'">
+                                <div class="uk-form-row">
+                                    <label for="form-mysql-dbhost" class="uk-form-label">{{ 'Hostname' | trans }}</label>
+                                    <div class="uk-form-controls">
+                                        <input id="form-mysql-dbhost" class="uk-width-1-1" type="text" name="host" value="localhost" v-model="config.database.connections.mysql.host" v-validate:required>
+                                        <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.host.invalid">{{ 'Host cannot be blank.' | trans }}</p>
+                                    </div>
+                                </div>
+                                <div class="uk-form-row">
+                                    <label for="form-mysql-dbuser" class="uk-form-label">{{ 'User' | trans }}</label>
+                                    <div class="uk-form-controls">
+                                        <input id="form-mysql-dbuser" class="uk-width-1-1" type="text" name="user" value="" v-model="config.database.connections.mysql.user" v-validate:required>
+                                        <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.user.invalid">{{ 'User cannot be blank.' | trans }}</p>
+                                    </div>
+                                </div>
+                                <div class="uk-form-row">
+                                    <label for="form-mysql-dbpassword" class="uk-form-label">{{ 'Password' | trans }}</label>
+                                    <div class="uk-form-controls">
+                                        <div class="uk-form-password uk-width-1-1">
+                                            <input id="form-mysql-dbpassword" class="uk-width-1-1" type="password" name="password" value="" autocomplete="off" v-model="config.database.connections.mysql.password">
+                                            <a class="uk-form-password-toggle" href="" tabindex="-1" data-uk-form-password="{ lblShow: 'Show', lblHide: 'Hide' }">{{ 'Show' | trans }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="uk-form-row">
+                                    <label for="form-mysql-dbname" class="uk-form-label">{{ 'Database Name' | trans }}</label>
+                                    <div class="uk-form-controls">
+                                        <input id="form-mysql-dbname" class="uk-width-1-1" type="text" name="dbname" value="pagekit" v-model="config.database.connections.mysql.dbname" v-validate:required>
+                                        <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.dbname.invalid">{{ 'Database name cannot be blank.' | trans }}</p>
+                                    </div>
+                                </div>
+                                <div class="uk-form-row">
+                                    <label for="form-mysql-dbprefix" class="uk-form-label">{{ 'Table Prefix' | trans }}</label>
+                                    <div class="uk-form-controls">
+                                        <input id="form-mysql-dbprefix" class="uk-width-1-1" type="text" name="mysqlprefix" value="pk_" v-model="config.database.connections.mysql.prefix" v-validate:pattern.literal="/^[a-zA-Z][a-zA-Z0-9._\-]*$/">
+                                        <p class="uk-form-help-block uk-text-danger" v-show="formDatabase.mysqlprefix.invalid">{{ 'Prefix must start with a letter and can only contain alphanumeric characters (A-Z, 0-9) and underscore (_)' | trans }}</p>
                                     </div>
                                 </div>
                             </div>

--- a/app/modules/config/src/ConfigManager.php
+++ b/app/modules/config/src/ConfigManager.php
@@ -3,6 +3,7 @@
 namespace Pagekit\Config;
 
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Pagekit\Database\Connection;
 
 class ConfigManager implements \IteratorAggregate
@@ -96,6 +97,8 @@ class ConfigManager implements \IteratorAggregate
             $data = ['name' => $name, 'value' => json_encode($config, JSON_UNESCAPED_UNICODE)];
 
             if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+                $this->connection->executeQuery("INSERT INTO {$this->table} (name, value) VALUES (:name, :value) ON DUPLICATE KEY UPDATE value = :value", $data);
+            } elseif ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
                 $this->connection->executeQuery("INSERT INTO {$this->table} (name, value) VALUES (:name, :value) ON DUPLICATE KEY UPDATE value = :value", $data);
             } elseif (!$this->connection->update($this->table, $data, compact('name'))) {
                 $this->connection->insert($this->table, $data);

--- a/app/modules/config/src/ConfigManager.php
+++ b/app/modules/config/src/ConfigManager.php
@@ -96,9 +96,7 @@ class ConfigManager implements \IteratorAggregate
 
             $data = ['name' => $name, 'value' => json_encode($config, JSON_UNESCAPED_UNICODE)];
 
-            if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
-                $this->connection->executeQuery("INSERT INTO {$this->table} (name, value) VALUES (:name, :value) ON DUPLICATE KEY UPDATE value = :value", $data);
-            } elseif ($this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+            if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform || $this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
                 $this->connection->executeQuery("INSERT INTO {$this->table} (name, value) VALUES (:name, :value) ON DUPLICATE KEY UPDATE value = :value", $data);
             } elseif (!$this->connection->update($this->table, $data, compact('name'))) {
                 $this->connection->insert($this->table, $data);

--- a/app/modules/database/index.php
+++ b/app/modules/database/index.php
@@ -84,6 +84,20 @@ $config = [
 
             ],
 
+            'pgsql' => [
+
+                'driver'   => 'pdo_pgsql',
+                'dbname'   => '',
+                'host'     => 'localhost',
+                'user'     => 'root',
+                'password' => '',
+//                'engine'   => 'InnoDB',
+                'charset'  => 'utf8',
+                'collate'  => 'utf8_unicode_ci',
+                'prefix'   => ''
+
+            ],
+
             'sqlite' => [
 
                 'driver' => 'pdo_sqlite',

--- a/app/modules/database/src/Query/QueryBuilder.php
+++ b/app/modules/database/src/Query/QueryBuilder.php
@@ -5,6 +5,7 @@ namespace Pagekit\Database\Query;
 use Closure;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Types\Type;
 use Pagekit\Database\Connection;
 use PDO;
@@ -251,6 +252,11 @@ class QueryBuilder
         $values = (array) $values;
 
         if (count($values) === 1 && $this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+            $value = $this->connection->quote(current($values));
+            return $this->addWhere("{$not} FIND_IN_SET({$value}, {$column})", [], $type);
+        }
+
+        if (count($values) === 1 && $this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
             $value = $this->connection->quote(current($values));
             return $this->addWhere("{$not} FIND_IN_SET({$value}, {$column})", [], $type);
         }

--- a/app/modules/session/src/Handler/DatabaseSessionHandler.php
+++ b/app/modules/session/src/Handler/DatabaseSessionHandler.php
@@ -140,11 +140,7 @@ class DatabaseSessionHandler implements \SessionHandlerInterface
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        if ($platform instanceof MySqlPlatform) {
-            return "INSERT INTO {$this->table} (id, data, time) VALUES (:id, :data, :time) "
-            . "ON DUPLICATE KEY UPDATE data = VALUES(data), time = CASE WHEN time = :time THEN (VALUES(time) + INTERVAL 1 SECOND) ELSE VALUES(time) END";
-
-        } elseif ($platform instanceof PostgreSqlPlatform) {
+        if ($platform instanceof MySqlPlatform || $platform instanceof PostgreSqlPlatform) {
             return "INSERT INTO {$this->table} (id, data, time) VALUES (:id, :data, :time) "
             . "ON DUPLICATE KEY UPDATE data = VALUES(data), time = CASE WHEN time = :time THEN (VALUES(time) + INTERVAL 1 SECOND) ELSE VALUES(time) END";
 

--- a/app/modules/session/src/Handler/DatabaseSessionHandler.php
+++ b/app/modules/session/src/Handler/DatabaseSessionHandler.php
@@ -4,6 +4,7 @@ namespace Pagekit\Session\Handler;
 
 use Doctrine\DBAL\ConnectionException;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Pagekit\Database\Connection;
 
@@ -142,6 +143,11 @@ class DatabaseSessionHandler implements \SessionHandlerInterface
         if ($platform instanceof MySqlPlatform) {
             return "INSERT INTO {$this->table} (id, data, time) VALUES (:id, :data, :time) "
             . "ON DUPLICATE KEY UPDATE data = VALUES(data), time = CASE WHEN time = :time THEN (VALUES(time) + INTERVAL 1 SECOND) ELSE VALUES(time) END";
+
+        } elseif ($platform instanceof PostgreSqlPlatform) {
+            return "INSERT INTO {$this->table} (id, data, time) VALUES (:id, :data, :time) "
+            . "ON DUPLICATE KEY UPDATE data = VALUES(data), time = CASE WHEN time = :time THEN (VALUES(time) + INTERVAL 1 SECOND) ELSE VALUES(time) END";
+
         } elseif ($platform instanceof SqlitePlatform) {
             return  "INSERT OR REPLACE INTO {$this->table} (id, data, time) VALUES (:id, :data, :time)";
         }


### PR DESCRIPTION
Some fixes to enable very important PostgreSQL support.

Why is so important? 

My simple example - on VPS, MySQL 5.7 eat all of RAM memory. And VPS crashed :(

Ok.

Because Pagekit connect to database through Doctrine DBAL, 
we should not many problems with adding some 
another DB (PostgreSQL or some another db).

I am not pro in JS. Say me plz, what we should fix to registration new pagekit copy works fine.
