### PR TITLE
Also get *.twig files to search for translations

### DIFF
--- a/app/console/src/Commands/ExtensionTranslateCommand.php
+++ b/app/console/src/Commands/ExtensionTranslateCommand.php
@@ -183,7 +183,7 @@ class ExtensionTranslateCommand extends Command
             $files->in($this->container->path().'/app/installer');
         }
 
-        return $files->name('*.{php,vue,js,html}');
+        return $files->name('*.{php,vue,js,html,twig}');
     }
 
     /**


### PR DESCRIPTION
Fix the getFiles method in ExtensionTranslateCommand to also search for translations in twig files with the .twig extension.
- [x ] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x ] The destination branch of the pull request is the `develop` branch
