### PR TITLE
get logout url from php

### DIFF
--- a/app/system/modules/theme/views/template.php
+++ b/app/system/modules/theme/views/template.php
@@ -39,7 +39,7 @@
                         <ul class="uk-grid uk-grid-small uk-flex-middle">
                             <li><a class="tm-icon-help" href="https://gitter.im/pagekit/pagekit" :title="'Get Help' | trans" target="_blank"></a></li>
                             <li><a class="tm-icon-visit" :href="$url.route('')" :title="'Visit Site' | trans" target="_blank"></a></li>
-                            <li><a class="tm-icon-logout" :href="$url.route('user/logout', {redirect: 'admin/login'})" :title="'Logout' | trans"></a></li>
+                            <li><a class="tm-icon-logout" href="<?= $view->url('@user/logout', ['redirect' => 'admin/login']) ?>" :title="'Logout' | trans"></a></li>
                             <li class="uk-margin-small-left"><a :href="$url.route('admin/user/edit', {id: user.id})" :title="'Profile' | trans"><img class="uk-border-circle uk-margin-small-right" height="32" width="32" :title="user.name" v-gravatar="user.email"> <span v-text="user.username"></span></a></li>
                         </ul>
 


### PR DESCRIPTION
When a logout-alias is created as a site-node, the `user/logout` url throws a 404 error. This fix gets the proper alias from the node.

Thanks for contributing. Please check the following points before submitting your pull request. Thank you!

- [x ] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [ x] The destination branch of the pull request is the `develop` branch
When a logout-alias is created as a site-node, the `user/logout` url throws a 404 error. This fix gets the proper alias from the node.