### PR TITLE
Fix async and defer options when loading scripts

### DIFF
--- a/app/modules/view/src/Asset/Asset.php
+++ b/app/modules/view/src/Asset/Asset.php
@@ -106,7 +106,7 @@ abstract class Asset implements AssetInterface, \ArrayAccess
      */
     public function getOption($name)
     {
-        return isset($this->options[$name]) ? $this->options[$name] : null;
+        return in_array($name, $this->options) ? $name : null;
     }
 
     /**


### PR DESCRIPTION
Options are stored as valued in the array, rather than a key.