### PR TITLE
Fix heading anchor parsing in the Render.php

### DIFF
--- a/app/modules/markdown/src/Renderer.php
+++ b/app/modules/markdown/src/Renderer.php
@@ -41,7 +41,7 @@ class Renderer
 
     public function heading($text, $level, $raw = '')
     {
-        $id = $this->options['headerPrefix'].preg_replace('/[^\w]+/m', '-', strtolower($raw));
+        $id = $this->options['headerPrefix'].preg_replace('/[^\w\-]+/m', '', preg_replace('/\s+/m', '-', strtolower($raw)));
 
         return "<h{$level} id=\"{$id}\">{$text}</h{$level}>\n";
     }


### PR DESCRIPTION
Fixing the way anchor IDs are being prepared for the way in which usually all Markdown link generating scripts work, e.g. TOC generating scripts never replace dots, braces etc. Only the spaces should be actually replaced with dashes.
