### PR TITLE
only update state when value is truthy

### DIFF
--- a/app/system/app/lib/state.js
+++ b/app/system/app/lib/state.js
@@ -9,8 +9,10 @@ module.exports = function (Vue) {
             vm.$set(key, current[1]);
         }
 
-        history.replaceState({key: key, value: this[key]}, '', value ? modifyQuery(location.search, key, value) : undefined);
-
+        if (value) {
+            history.replaceState({key: key, value: this[key]}, '', modifyQuery(location.search, key, value));
+        }
+        
         this.$watch(key, function (value) {
             history.pushState({key: key, value: value}, '', modifyQuery(location.search, key, value));
         });


### PR DESCRIPTION
passing undefined to `replaceState` causes the url to change to http://www.domain.com/undefined on Edge and IE.