### PR TITLE
rm point in $trans regex

### DIFF
--- a/app/console/src/Commands/ExtensionTranslateCommand.php
+++ b/app/console/src/Commands/ExtensionTranslateCommand.php
@@ -134,9 +134,9 @@ class ExtensionTranslateCommand extends Command
         }
 
         // vue, js files
-        // something.$trans('foo', [args])
-        // something.$transChoice('foo'[, args])
-        preg_match_all('/\.\$trans(Choice)?\((\'|")((?:(?!\2).)+)\2/', $content, $matches);
+        // $trans('foo', [args])
+        // $transChoice('foo'[, args])
+        preg_match_all('/\$trans(Choice)?\((\'|")((?:(?!\2).)+)\2/', $content, $matches);
         foreach ($matches[3] as $i => $string) {
             $domain = 'messages'; // TODO: allow custom domain
 


### PR DESCRIPTION
When `$trans` is used in html-attributes, there is no object or point notation; `:title="$trans('My translated title')"`

Thanks for contributing. Please check the following points before submitting your pull request. Thank you!

- [x ] I have read and followed the contribution guide: https://github.com/pagekit/pagekit/blob/develop/.github/CONTRIBUTING.md
- [x ] The destination branch of the pull request is the `develop` branch
When `$trans` is used in html-attributes, there is no object or point notation; `:title="$trans('My translated title')"`