### PR TITLE
Changed autoloader to work with path variable

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -2,26 +2,26 @@
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-$loader = require __DIR__ . '/app/vendor/autoload.php';
+$loader = require $path . '/app/vendor/autoload.php';
 
-if (file_exists(__DIR__ . '/packages/autoload.php')) {
-    $map = require __DIR__ . '/packages/composer/autoload_namespaces.php';
+if (file_exists($path . '/packages/autoload.php')) {
+    $map = require $path . '/packages/composer/autoload_namespaces.php';
     foreach ($map as $namespace => $p) {
         $loader->set($namespace, $p);
     }
 
-    $map = require __DIR__ . '/packages/composer/autoload_psr4.php';
+    $map = require $path . '/packages/composer/autoload_psr4.php';
     foreach ($map as $namespace => $p) {
         $loader->setPsr4($namespace, $p);
     }
 
-    $classMap = require __DIR__ . '/packages/composer/autoload_classmap.php';
+    $classMap = require $path . '/packages/composer/autoload_classmap.php';
     if ($classMap) {
         $loader->addClassMap($classMap);
     }
 
-    if (file_exists(__DIR__ . '/packages/composer/autoload_files.php')) {
-        $includeFiles = require __DIR__ . '/packages/composer/autoload_files.php';
+    if (file_exists($path . '/packages/composer/autoload_files.php')) {
+        $includeFiles = require $path . '/packages/composer/autoload_files.php';
         foreach ($includeFiles as $file) {
             require $file;
         }


### PR DESCRIPTION
Using `$path` instead of `__DIR__` allows for cronjob files (or other CLI called files) to include autoload.php and pass their own `$path` from there.

ie:

```
use Pagekit\Application as App;
use Pagekit\Module\Loader\ConfigLoader;

$path = realpath(__DIR__ . '/../../../../..');
$config = array(
    'path'          => $path,
    'path.packages' => $path.'/packages',
    'path.storage'  => $path.'/storage',
    'path.temp'     => $path.'/tmp/temp',
    'path.cache'    => $path.'/tmp/cache',
    'path.logs'     => $path.'/tmp/logs',
    'path.vendor'   => $path.'/vendor',
    'path.artifact' => $path.'/tmp/packages',
    'config.file'   => realpath($path.'/config.php'),
    'system.api'    => 'https://pagekit.com'
);

$loader = require $path . '/autoload.php';

$app['module']->register([
    'packages/*/*/index.php',
    'app/modules/*/index.php',
    'app/installer/index.php',
    'app/system/index.php'
], $path);

$app['module']->addLoader(new AutoLoader($app['autoloader']));
$app['module']->addLoader(new ConfigLoader(require $path.'/app/system/config.php'));
$app['module']->addLoader(new ConfigLoader(require $path.'/config.php'));
$app['module']->addLoader(new ConfigLoader(require $app['config.file']));
$app['module']->load('system');

$app->boot();

<your own code here>
```