### PR TITLE
Fix: "Unknown database type enum requested"

### DIFF
--- a/app/modules/database/src/Utility.php
+++ b/app/modules/database/src/Utility.php
@@ -34,6 +34,7 @@ class Utility
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
+        $this->connection->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
         $this->manager = $this->connection->getSchemaManager();
         $this->schema = $this->manager->createSchema();
     }


### PR DESCRIPTION
Fix: "Unknown database type enum requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it."

Bug with database if already exists a table with a column type of "enum". Pagekit crashes.