### PR TITLE
Avoid setting cookie_path if session was already started

### DIFF
--- a/app/modules/session/index.php
+++ b/app/modules/session/index.php
@@ -82,7 +82,7 @@ return [
 
         'request' => [function ($event, $request) use ($app) {
 
-            if (!isset($app['session.options']['cookie_path'])) {
+            if (session_status() == PHP_SESSION_NONE && !isset($app['session.options']['cookie_path'])) {
                 $app['session.storage']->setOptions(['cookie_path' => $request->getBasePath() ?: '/']);
             }
 


### PR DESCRIPTION
This fix avoids a php warning 