### PR TITLE
Security Fix for User Enumeration - huntr.dev

### DIFF
--- a/app/system/modules/user/src/Controller/ResetPasswordController.php
+++ b/app/system/modules/user/src/Controller/ResetPasswordController.php
@@ -44,7 +44,7 @@ class ResetPasswordController
             }
 
             if (!$user = User::findByEmail($email)) {
-                throw new Exception(__('Unknown email address.'));
+                throw new Exception(__('If this email exists, you will receive an email with the reset instructions.'));
             }
 
             if ($user->isBlocked()) {
@@ -69,7 +69,7 @@ class ResetPasswordController
             $user->activation = $key;
             $user->save();
 
-            App::message()->success(__('Check your email for the confirmation link.'));
+            App::message()->success(__('If this email exists, you will receive an email with the reset instructions.'));
 
             return App::redirect('@user/login');
 


### PR DESCRIPTION
https://huntr.dev/users/mufeedvh has fixed the User Enumeration vulnerability 🔨. mufeedvh has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/pagekit/pull/1
GitHub Issue URL | https://github.com/pagekit/pagekit/issues/935
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/packagist/pagekit/1/README.md

### User Comments:

### 📊 Metadata *

#### Bounty URL:  https://www.huntr.dev/bounties/1-packagist-pagekit

### ⚙️ Description *

`pagekit` is vulnerable to **Username Enumeration** as the response message on the Reset Password page when an email exists or vise-versa differs making it easy for an attacker to assume an account exists or not.

### 💻 Technical Description *

An attacker can know if a certain email/user exists or not just by giving in a victim's email address.

If the email exists, the request responds with:

```
Check your email for the confirmation link.
```

If it doesn't, it responds with:

```
Unknown email address.
```

The function resides in the `/pagekit/app/system/modules/user/src/Controller/ResetPasswordController.php`:

```php
public function requestAction($email)
{
    try {

        if (App::user()->isAuthenticated()) {
            return App::redirect();
        }

        if (!App::csrf()->validate()) {
            throw new Exception(__('Invalid token. Please try again.'));
        }

        if (empty($email)) {
            throw new Exception(__('Enter a valid email address.'));
        }

        if (!$user = User::findByEmail($email)) {
            throw new Exception(__('Unknown email address.'));
        }

        if ($user->isBlocked()) {
            throw new Exception(__('Your account has not been activated or is blocked.'));
        }

        $key = App::get('auth.random')->generateString(32);
        $url = App::url('@user/resetpassword/confirm', compact('key'), 0);

        try {

            $mail = App::mailer()->create();
            $mail->setTo($user->email)
                ->setSubject(__('Reset password for %site%.', ['%site%' => App::module('system/site')->config('title')]))
                ->setBody(App::view('system/user:mails/reset.php', compact('user', 'url', 'mail')), 'text/html')
                ->send();

        } catch (\Exception $e) {
            throw new Exception(__('Unable to send confirmation link.'));
        }

        $user->activation = $key;
        $user->save();

        App::message()->success(__('Check your email for the confirmation link.'));

        return App::redirect('@user/login');

    } catch (Exception $e) {
        return [
            '$view' => [
                'title' => __('Reset'),
                'name' => 'system/user/reset-request.php',
            ],
            'error' => $e->getMessage()
        ];
    }
}
```

As you can see, the response comes from these exceptions:

```php
if (!$user = User::findByEmail($email)) {
    throw new Exception(__('Unknown email address.'));
}
```

and

```php
App::message()->success(__('Check your email for the confirmation link.'));
```

_**Just changing these strings are enough to fix the issue. To not enable the attacker to enumerate users, we can change the strings to:**_

```
If this email exists, you will receive an email with the reset instructions.
```

### 🐛 Proof of Concept (PoC) *

**The PoC is nicely detailed in this issue:** https://github.com/pagekit/pagekit/issues/935

![poc-pagekit-1](https://user-images.githubusercontent.com/26198477/88807657-9ff09100-d1cf-11ea-8000-b1fbb73c1ee0.png)

![poc-pagekit-2](https://user-images.githubusercontent.com/26198477/88807680-a848cc00-d1cf-11ea-98ae-9c87e9a8879a.png)

**As you can see it's just a string response, so changing them are enough to fix the issue.**

### 🔥 Proof of Fix (PoF) *

Changed the two strings to `If this email exists, you will receive an email with the reset instructions.` making it unable for an attacker to identify account existence.

```php
if (!$user = User::findByEmail($email)) {
    throw new Exception(__('If this email exists, you will receive an email with the reset instructions.'));
}
```

```php
App::message()->success(__('If this email exists, you will receive an email with the reset instructions.'));
```

### 👍 User Acceptance Testing (UAT)

Just a string change, no breaking changes are introduced.